### PR TITLE
Update references with Markdown footnote syntax

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@
 
 [![report](https://img.shields.io/badge/quickstart-green)](./doc/quickstart.md) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1Cyvu_lPFUajr2RKt6yJIfS3HQIIYl6QU?usp=sharing)
 
-This is the basic code for fitting SMPL[1]/SMPL+H[2]/SMPL-X[3]/MANO[2] model to capture body+hand+face poses from multiple views.
+This is the basic code for fitting SMPL[^loper2015]/SMPL+H[^romero2017]/SMPL-X[^pavlakos2019]/MANO[^romero2017] model to capture body+hand+face poses from multiple views.
 
 <div align="center">
     <img src="doc/feng/mv1pmf-smplx.gif" width="80%">
@@ -162,9 +162,9 @@ Here are the great works this project is built upon:
 - The method for fitting 3D skeleton and SMPL model is similar to [TotalCapture](http://www.cs.cmu.edu/~hanbyulj/totalcapture/), without using point clouds.
 - We integrate some easy-to-use functions for previous great work:
   - `easymocap/estimator/mediapipe_wrapper.py`: [MediaPipe](https://github.com/google/mediapipe)
-  - `easymocap/estimator/SPIN`  : an SMPL estimator[5]
-  - `easymocap/estimator/YOLOv4`: an object detector[6](Coming soon)
-  - `easymocap/estimator/HRNet` : a 2D human pose estimator[7](Coming soon)
+  - `easymocap/estimator/SPIN`  : an SMPL estimator[^cao2018]
+  - `easymocap/estimator/YOLOv4`: an object detector[^kolotouros2019] (Coming soon)
+  - `easymocap/estimator/HRNet` : a 2D human pose estimator[^bochkovskiy2020] (Coming soon)
 
 ## Contact
 
@@ -184,7 +184,6 @@ This project is a part of our work [iMocap](https://zju3dv.github.io/iMoCap/), [
 Please consider citing these works if you find this repo is useful for your projects.
 
 ```bibtex
-    
 @inproceedings{dong2021fast,
   title={Fast and Robust Multi-Person 3D Pose Estimation and Tracking from Multiple Views},
   author={Dong, Junting and Fang, Qi and Jiang, Wen and Yang, Yurou and Bao, Hujun and Zhou, Xiaowei},
@@ -217,15 +216,18 @@ Please consider citing these works if you find this repo is useful for your proj
 
 ```
 
-## Reference
+[^loper2015]: Loper, Matthew, et al. "SMPL: A skinned multi-person linear model." ACM transactions on graphics (TOG) 34.6 (2015): 1-16.
 
-```bash
-[1] Loper, Matthew, et al. "SMPL: A skinned multi-person linear model." ACM transactions on graphics (TOG) 34.6 (2015): 1-16.
-[2] Romero, Javier, Dimitrios Tzionas, and Michael J. Black. "Embodied hands: Modeling and capturing hands and bodies together." ACM Transactions on Graphics (ToG) 36.6 (2017): 1-17.
-[3] Pavlakos, Georgios, et al. "Expressive body capture: 3d hands, face, and body from a single image." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2019.
-[4] Bogo, Federica, et al. "Keep it SMPL: Automatic estimation of 3D human pose and shape from a single image." European conference on computer vision. Springer, Cham, 2016.
-[5] Cao, Z., Hidalgo, G., Simon, T., Wei, S.E., Sheikh, Y.: Openpose: real-time multi-person 2d pose estimation using part affinity fields. arXiv preprint arXiv:1812.08008 (2018)
-[6] Kolotouros, Nikos, et al. "Learning to reconstruct 3D human pose and shape via model-fitting in the loop." Proceedings of the IEEE/CVF International Conference on Computer Vision. 2019
-[7] Bochkovskiy, Alexey, Chien-Yao Wang, and Hong-Yuan Mark Liao. "Yolov4: Optimal speed and accuracy of object detection." arXiv preprint arXiv:2004.10934 (2020).
-[8] Sun, Ke, et al. "Deep high-resolution representation learning for human pose estimation." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2019.
-```
+[^romero2017]: Romero, Javier, Dimitrios Tzionas, and Michael J. Black. "Embodied hands: Modeling and capturing hands and bodies together." ACM Transactions on Graphics (ToG) 36.6 (2017): 1-17.
+
+[^pavlakos2019]: Pavlakos, Georgios, et al. "Expressive body capture: 3d hands, face, and body from a single image." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2019.
+
+<!-- [4] Bogo, Federica, et al. "Keep it SMPL: Automatic estimation of 3D human pose and shape from a single image." European conference on computer vision. Springer, Cham, 2016. -->
+
+[^cao2018]: Cao, Z., Hidalgo, G., Simon, T., Wei, S.E., Sheikh, Y.: Openpose: real-time multi-person 2d pose estimation using part affinity fields. arXiv preprint arXiv:1812.08008 (2018)
+
+[^kolotouros2019]: Kolotouros, Nikos, et al. "Learning to reconstruct 3D human pose and shape via model-fitting in the loop." Proceedings of the IEEE/CVF International Conference on Computer Vision. 2019
+
+[^bochkovskiy2020]: Bochkovskiy, Alexey, Chien-Yao Wang, and Hong-Yuan Mark Liao. "Yolov4: Optimal speed and accuracy of object detection." arXiv preprint arXiv:2004.10934 (2020).
+
+<!-- [8] Sun, Ke, et al. "Deep high-resolution representation learning for human pose estimation." Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition. 2019. -->


### PR DESCRIPTION
GitHub supports Markdown footnote syntax, and in VS Code it is supported by a somehow "official" [extension](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-footnotes).

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/7588612/149622283-0aceedb6-ad5b-47f0-9e60-5ef5a6f3f4c3.png)|![image](https://user-images.githubusercontent.com/7588612/149622267-e3bab625-2512-40a7-adda-92bd0091a3c5.png)|
|![image](https://user-images.githubusercontent.com/7588612/149622333-503b98a7-d44e-4ba3-80cc-88829854b36b.png)|![image](https://user-images.githubusercontent.com/7588612/149622318-907219e0-a4d3-4643-b44e-e65dc655823d.png)|

I am not sure whether the original numbering of 5/6/7 is correct (after the change of #107) and there are two unused references (4 and 8). Please feel free to fix it (their ids are now in the `authoryear` format).