### PR TITLE
fix repro_smpl projectN3 error

### DIFF
--- a/easymocap/mytools/reconstruction.py
+++ b/easymocap/mytools/reconstruction.py
@@ -24,7 +24,8 @@ def projectN3(kpts3d, Pall):
         kp2d[:2, :] /= kp2d[2:, :]
         kp2ds.append(kp2d.T[None, :, :])
     kp2ds = np.vstack(kp2ds)
-    kp2ds[..., -1] = kp2ds[..., -1] * (kpts3d[None, :, -1] > 0.)
+    if kpts3d.shape[-1] == 4:
+        kp2ds[..., -1] = kp2ds[..., -1] * (kpts3d[None, :, -1] > 0.)
     return kp2ds
 
 def simple_reprojection_error(kpts1, kpts1_proj):


### PR DESCRIPTION
when vis repro_smpl, the kpts3d shape is [x,x,3], it has no visibility,it has xyz only, use z maybe lost some point in repro_smpl.