### PR TITLE
fix merge conflict of assignment

### DIFF
--- a/easymocap/assignment/associate.py
+++ b/easymocap/assignment/associate.py
@@ -77,9 +77,9 @@ def simple_associate(annots, affinity, dimGroups, Pall, group, cfg):
             err = ((kptsRepro[:, :, 2]*keypoints2d[:, :, 2]) > 0.) * np.linalg.norm(kptsRepro[:, :, :2] - keypoints2d[:, :, :2], axis=2)
             size = (bboxes[:, [2, 3]] - bboxes[:, [0, 1]]).max(axis=1, keepdims=True)
             err = err / size
-            err_view = err.sum(axis=1)/((err>0.).sum(axis=1))
+            err_view = err.sum(axis=1)/((err>0. + 1e-9).sum(axis=1))
             flag = (err_view < cfg.max_repro_error).all()
-            err = err.sum()/(err>0).sum()
+            err = err.sum()/(err>0 + 1e-9).sum()
             # err_view = err.sum(axis=1)/((err>0.).sum(axis=1))
             # err = err.sum()/(err>0.).sum()
             # flag = err_view.max() < err_view.mean() * 2

--- a/easymocap/assignment/criterion.py
+++ b/easymocap/assignment/criterion.py
@@ -76,6 +76,8 @@ class CritMinMax(BaseCrit):
     def __call__(self, keypoints3d, **kwargs):
         idx = keypoints3d[..., -1] > self.min_conf
         k3d = keypoints3d[idx, :3]
+        if sum(idx) == 0:
+            return False
         mink = np.min(k3d, axis=0)
         maxk = np.max(k3d, axis=0)
         length = max(np.abs(maxk - mink))

--- a/easymocap/assignment/track.py
+++ b/easymocap/assignment/track.py
@@ -90,12 +90,16 @@ class BaseTrack:
             # directly assign
             if id0 != -1 and id1 == -1:
                 if nf1 in frames_of_id[id0].keys():
-                    log('Merge conflict')
+                    log(f'Merge conflict1 nf0: {nf0} ni0: {ni0} id0: {id0} nf1: {nf1} ni1: {ni1} id1: {id1}')
+                    continue
                 results[nf1][ni1]['id'] = id0
                 # log('Merge person {}'.format(maxid))
                 frames_of_id[id0][nf1] = ni1
                 continue
             if id0 == -1 and id1 != -1:
+                if nf0 in frames_of_id[id1].keys():
+                    log(f'Merge conflict2 nf0: {nf0} ni0: {ni0} id0: {id0} nf1: {nf1} ni1: {ni1} id1: {id1}')
+                    continue
                 results[nf0][ni0]['id'] = id1
                 frames_of_id[id1][nf0] = ni0
                 continue

--- a/easymocap/mytools/reconstruction.py
+++ b/easymocap/mytools/reconstruction.py
@@ -24,7 +24,8 @@ def projectN3(kpts3d, Pall):
         kp2d[:2, :] /= kp2d[2:, :]
         kp2ds.append(kp2d.T[None, :, :])
     kp2ds = np.vstack(kp2ds)
-    kp2ds[..., -1] = kp2ds[..., -1] * (kpts3d[None, :, -1] > 0.)
+    if kpts3d.shape[-1] == 4:
+        kp2ds[..., -1] = kp2ds[..., -1] * (kpts3d[None, :, -1] > 0.)
     return kp2ds
 
 def simple_reprojection_error(kpts1, kpts1_proj):


### PR DESCRIPTION
This fix avoids a condition where people are multiple assigned in a frame. After that at times
when they are popped from the frames in the below merge code, there are still some frames
with that ID which triggers a later key errors when trying to look them up in the frame dictionary.