### PR TITLE
Fix typo in file convert2bvh.py

### DIFF
--- a/scripts/postprocess/convert2bvh.py
+++ b/scripts/postprocess/convert2bvh.py
@@ -152,7 +152,7 @@ def read_smpl(outname):
     assert os.path.exists(outname), outname
     datas = read_json(outname)
     outputs = []
-    if isinstace(datas, dict):
+    if isinstance(datas, dict):
         datas = datas['annots']
     for data in datas:
         for key in ['Rh', 'Th', 'poses', 'shapes']:


### PR DESCRIPTION
typo error in line 155. isinstace => isinstance