### PR TITLE
Fix Quick Start Demo of mv1p

### DIFF
--- a/easymocap/datasets/base.py
+++ b/easymocap/datasets/base.py
@@ -42,6 +42,10 @@ def get_allname(root0, subs, ranges, root, ext, **kwargs):
         else:
             _ranges = ranges
         nv = subs.index(sub)
+
+        if len(imgnames) < _ranges[1]:
+            raise ValueError('The number of images in {} is less than the range: {} vs {}'.format(join(root0, root, sub), len(imgnames), _ranges[1]))
+
         for nnf, nf in enumerate(range(*_ranges)):
             image_names.append({
                 'sub': sub,

--- a/easymocap/datasets/base.py
+++ b/easymocap/datasets/base.py
@@ -230,7 +230,7 @@ class Base(BaseData):
         self.reader = reader
         self.writer = writer
         if camera != 'none':
-            if not os.path.isabs(camera):
+            if not os.path.exists(camera) and not os.path.isabs(camera):
                 camera = join(self.root, camera)
             if os.path.exists(camera):
                 cameras = read_cameras(camera)
@@ -464,7 +464,10 @@ class ImageFolder(Base):
                         data[key] = Undistort.points(data[key], K, dist)
                         data[key+'_unproj'] = unproj(data[key], invK)
                     for _key in [key, key+'_distort', key+'_unproj']:
-                        self.cache_shape[_key] = np.zeros_like(data[_key])
+                        try:
+                            self.cache_shape[_key] = np.zeros_like(data[_key])
+                        except KeyError:
+                            print(f"missed key: {_key}")
         if self.loadmp:
             data['annots'] = data['annots']['annots']
             # compose the data

--- a/easymocap/estimator/openpose_wrapper.py
+++ b/easymocap/estimator/openpose_wrapper.py
@@ -18,6 +18,9 @@ from glob import glob
 from multiprocessing import Process
 
 def run_openpose(image_root, annot_root, config):
+    image_root = os.path.realpath(image_root)
+    annot_root = os.path.realpath(annot_root)
+
     os.makedirs(annot_root, exist_ok=True)
     pwd = os.getcwd()
     if os.name != 'nt':

--- a/easymocap/multistage/base_ops.py
+++ b/easymocap/multistage/base_ops.py
@@ -33,7 +33,7 @@ class SkipPoses(BeforeAfterBase):
     def before(self, body_params):
         poses = body_params['poses']
         poses_copy = torch.zeros_like(poses)
-        print(poses.shape)
+        # print(poses.shape)
         poses_copy[..., self.copy_index] = poses[..., self.copy_index]
         body_params['poses'] = poses_copy
         return body_params


### PR DESCRIPTION
## tl;dr: 

Fix lightstage mv1p demo from https://chingswy.github.io/easymocap-public-doc/quickstart/quickstart.html, and other minor bugs and distracted prints.

```
python3 apps/demo/mocap.py ${data} --work lightstage-dense-smplh --subs_vis 01 --ranges 0 800 1
```

when `${data}` is relative path, the workflow fails.

## Related issue: 

Fix #258.

## Cause

`triangulation1p.py` fails.

By default the `camera` is `'none'`, then `kwargs['camera']=kwargs['path']`.
Due to data loading error from `easymocap/datasets/base.py`. https://github.com/zju3dv/EasyMocap/blob/7a80646902420692dcb2376abbd23ec5d0138d6d/easymocap/datasets/base.py#L509-L510

When the `kwargs['path']` is relative path, e.g. `./data/zju_mocap/302/`, the `camera` at https://github.com/zju3dv/EasyMocap/blob/7a80646902420692dcb2376abbd23ec5d0138d6d/easymocap/datasets/base.py#L233-L234 turn into `./data/zju_mocap/302/data/zju_mocap/302/`. Thus the camera information is not loaded, causing `keypoint2d_unproj` at https://github.com/zju3dv/EasyMocap/blob/7a80646902420692dcb2376abbd23ec5d0138d6d/easymocap/datasets/base.py#L466-L467
missing in dataloader.

## Misc

Other fixes includes, remove redundant print, check image iteration boundary, and openpose data directory with relative path. 