### PR TITLE
Replace np.int with int given the deprecation

### DIFF
--- a/apps/calibration/check_calib.py
+++ b/apps/calibration/check_calib.py
@@ -52,7 +52,7 @@ def load_cube():
         [1, 5],
         [2, 6],
         [3, 7]
-    ], dtype=np.int)
+    ], dtype=int)
     points3d = np.hstack((points3d, np.ones((points3d.shape[0], 1))))
     return points3d, lines
 
@@ -100,7 +100,7 @@ def load_axes():
         [0,1],
         [0,2],
         [0,3]
-    ], dtype=np.int)
+    ], dtype=int)
     points3d = np.hstack((points3d, np.ones((points3d.shape[0], 1))))
     return points3d, lines
 

--- a/easymocap/affinity/affinity.py
+++ b/easymocap/affinity/affinity.py
@@ -13,7 +13,7 @@ def getDimGroups(lDetections):
     dimGroups = [0]
     for data in lDetections:
         dimGroups.append(dimGroups[-1] + len(data))
-    views = np.zeros(dimGroups[-1], dtype=np.int)
+    views = np.zeros(dimGroups[-1], dtype=int)
     for nv in range(len(dimGroups) - 1):
         views[dimGroups[nv]:dimGroups[nv+1]] = nv
     return dimGroups, views

--- a/easymocap/assignment/associate.py
+++ b/easymocap/assignment/associate.py
@@ -10,7 +10,7 @@ from ..mytools.reconstruction import batch_triangulate, projectN3
 from ..config import load_object
 
 def views_from_dimGroups(dimGroups):
-    views = np.zeros(dimGroups[-1], dtype=np.int)
+    views = np.zeros(dimGroups[-1], dtype=int)
     for nv in range(len(dimGroups) - 1):
         views[dimGroups[nv]:dimGroups[nv+1]] = nv
     return views
@@ -42,8 +42,8 @@ def simple_associate(annots, affinity, dimGroups, Pall, group, cfg):
         views_cnt[:, nv] = affinity[:, dimGroups[nv]:dimGroups[nv+1]].sum(axis=1)
     views_cnt = (views_cnt>0.5).sum(axis=1)
     sortidx = np.argsort(-views_cnt)
-    p2dAssigned = np.zeros(n2D, dtype=np.int) - 1
-    indices_zero = np.zeros((nViews), dtype=np.int) - 1
+    p2dAssigned = np.zeros(n2D, dtype=int) - 1
+    indices_zero = np.zeros((nViews), dtype=int) - 1
     for idx in sortidx:
         if p2dAssigned[idx] != -1:
             continue

--- a/easymocap/dataset/mirror.py
+++ b/easymocap/dataset/mirror.py
@@ -15,7 +15,7 @@ FLIP_BODYHAND = [
     0,1,5,6,7,2,3,4,8,12,13,14,9,10,11,16,15,18,17,22,23,24,19,20,21, # body 25
     22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, # right hand
     ]
-FLIP_SMPL_VERTICES = np.loadtxt(join(os.path.dirname(__file__), 'smpl_vert_sym.txt'), dtype=np.int)
+FLIP_SMPL_VERTICES = np.loadtxt(join(os.path.dirname(__file__), 'smpl_vert_sym.txt'), dtype=int)
 
 def flipPoint2D(point):
     if point.shape[-2] == 25:

--- a/easymocap/multistage/fitting.py
+++ b/easymocap/multistage/fitting.py
@@ -208,7 +208,7 @@ class BaseBody:
         parents = body_model.parents[1:].cpu().numpy()
         child = np.arange(1, parents.shape[0]+1, dtype=np.int64)
         self.kintree = np.stack([parents, child], axis=1)
-        self.parents = np.zeros(parents.shape[0]+1, dtype=np.int) - 1
+        self.parents = np.zeros(parents.shape[0]+1, dtype=int) - 1
         self.parents[self.kintree[:, 1]] = self.kintree[:, 0]
         self.rootIdx = 0
         self.time = time()
@@ -490,7 +490,7 @@ class MyFilter:
             value_mean = (value_pre * conf_pre).sum(axis=0)/(conf_sum + 1e-5)
             self.x = value_mean
             self.x_conf = conf_sum
-            t_prev = np.zeros_like(self.x, dtype=np.int) - 1
+            t_prev = np.zeros_like(self.x, dtype=int) - 1
             t_prev[conf_sum>0] = self.counter
             self.t_prev = t_prev
             # 零速度初始化

--- a/easymocap/mytools/triangulator.py
+++ b/easymocap/mytools/triangulator.py
@@ -385,7 +385,7 @@ def check_cluster(affinity, row, views, dimGroups, indices, p2dAssigned, visited
     return indices_all
 
 def views_from_dimGroups(dimGroups):
-    views = np.zeros(dimGroups[-1], dtype=np.int)
+    views = np.zeros(dimGroups[-1], dtype=int)
     for nv in range(len(dimGroups) - 1):
         views[dimGroups[nv]:dimGroups[nv+1]] = nv
     return views
@@ -462,11 +462,11 @@ class SimpleMatchAndTriangulator(SimpleTriangulator):
             sum1 += affinity[:, start:end].max(axis=-1)
         n2d = affinity.shape[0]
         nViews = len(dimGroups) - 1
-        idx_zero = np.zeros(nViews, dtype=np.int) - 1
+        idx_zero = np.zeros(nViews, dtype=int) - 1
         views = views_from_dimGroups(dimGroups)
         # the assigned results of each person
-        p2dAssigned = np.zeros(n2d, dtype=np.int) - 1
-        visited = np.zeros(n2d, dtype=np.int)
+        p2dAssigned = np.zeros(n2d, dtype=int) - 1
+        visited = np.zeros(n2d, dtype=int)
         sortidx = np.argsort(-sum1)
         pid = 0
         k3dresults = []

--- a/easymocap/pyfitting/optimize_simple.py
+++ b/easymocap/pyfitting/optimize_simple.py
@@ -26,7 +26,7 @@ def optimizeShape(body_model, body_params, keypoints3d,
     """
     device = body_model.device
     # 计算不同的骨长
-    kintree = np.array(kintree, dtype=np.int)
+    kintree = np.array(kintree, dtype=int)
     # limb_length: nFrames, nLimbs, 1
     limb_length = np.linalg.norm(keypoints3d[:, kintree[:, 1], :3] - keypoints3d[:, kintree[:, 0], :3], axis=2, keepdims=True)
     # conf: nFrames, nLimbs, 1

--- a/easymocap/visualize/geometry.py
+++ b/easymocap/visualize/geometry.py
@@ -13,13 +13,13 @@ from os.path import join
 
 def load_sphere():
     cur_dir = os.path.dirname(__file__)
-    faces = np.loadtxt(join(cur_dir, 'sphere_faces_20.txt'), dtype=np.int)
+    faces = np.loadtxt(join(cur_dir, 'sphere_faces_20.txt'), dtype=int)
     vertices = np.loadtxt(join(cur_dir, 'sphere_vertices_20.txt'))
     return vertices, faces
 
 def load_cylinder():
     cur_dir = os.path.dirname(__file__)
-    faces = np.loadtxt(join(cur_dir, 'cylinder_faces_20.txt'), dtype=np.int)
+    faces = np.loadtxt(join(cur_dir, 'cylinder_faces_20.txt'), dtype=int)
     vertices = np.loadtxt(join(cur_dir, 'cylinder_vertices_20.txt'))
     return vertices, faces
 

--- a/easymocap/visualize/skelmodel.py
+++ b/easymocap/visualize/skelmodel.py
@@ -50,7 +50,7 @@ class SkelModel:
         self.body_type = body_type
         self.device = 'none'
         cur_dir = os.path.dirname(__file__)
-        faces = np.loadtxt(join(cur_dir, 'assets', 'sphere_faces_{}.txt'.format(res)), dtype=np.int)
+        faces = np.loadtxt(join(cur_dir, 'assets', 'sphere_faces_{}.txt'.format(res)), dtype=int)
         self.vertices = np.loadtxt(join(cur_dir, 'assets', 'sphere_vertices_{}.txt'.format(res)))
         # compose faces
         faces_all = []


### PR DESCRIPTION
np.int is now deprecated:
   https://numpy.org/devdocs/release/1.20.0-notes.html

this replaces usage of it with int, which the prior alias did.